### PR TITLE
Add feature wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ crate-type = ["cdylib", "rlib"]
 # OpenCC rulesets are disabled by default.
 # Enabling the feature may improve accuracy at the cost of binary size bloating and performance
 # degration.
-default = ["compress"]
+default = ["compress", "wasm"]
+wasm = []
 opencc = ["lazy_static"]
 compress = ["zstd", "ruzstd"]
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,6 +11,7 @@ pub(crate) use get_with_fallback;
 macro_rules! for_wasm {
     ($($item:item)*) => {$(
         #[cfg(target_arch = "wasm32")]
+        #[cfg(feature = "wasm")]
         $item
     )*}
 }


### PR DESCRIPTION
Currently `zhconv-rs` forcibly adds `#[wasm_bindgen]` to its public functions when `target = wasm`, leading to that these functions _always_ appear in the generated binary, which is not desired when `zhconv-rs` is used as an dependency for a wasm program. This PR adds a feature to disable such behavior.